### PR TITLE
Cleanup graphite cronjob a bit and add cron_job attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ CHANGELOG
 Chef-Bareos Cookbook
 --------------------
 
+3.0.4
+-----
+#### Ian Smith
+  * Updating the cronjob resource to only be included if user specifies a desire to enable a cronjob, defaults to off
+
 3.0.3
 -----
 #### Ian Smith

--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ A new plugin that will send statistics to a graphite server which can then be us
 | ['bareos']['plugins']['graphite']['graphite_port'] | '2003' | Default graphite communication port
 | ['bareos']['plugins']['graphite']['graphite_data_prefix'] | 'bareos.' | Default prefix for graphite data
 | ['bareos']['plugins']['graphite']['graphite_plugin_src_url'] | See attributes file | Default URL to the plugin
+| ['bareos']['plugins']['graphite']['cron_job'] | nil | Activates a general minutely cronjob if defined other than nil
 
 ## Recipes
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -8,11 +8,11 @@ issues_url        'https://github.com/sitle/chef-bareos/issues'
 source_url        'https://github.com/sitle/chef-bareos.git'
 version           '3.0.4'
 
-%w( centos redhat ).each do |os|
+%w(centos redhat).each do |os|
   supports os, '>= 6.0'
 end
 
-%w( debian ubuntu ).each do |os|
+%w(debian ubuntu).each do |os|
   supports os
 end
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ description       'Installs/Configures BAREOS - Backup Archiving REcovery Open S
 long_description  IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 issues_url        'https://github.com/sitle/chef-bareos/issues'
 source_url        'https://github.com/sitle/chef-bareos.git'
-version           '3.0.3'
+version           '3.0.4'
 
 %w( centos redhat ).each do |os|
   supports os, '>= 6.0'

--- a/recipes/client.rb
+++ b/recipes/client.rb
@@ -19,8 +19,8 @@
 
 # Include the OpenSSL library for generating random passwords
 ::Chef::Recipe.send(:include, OpenSSLCookbook::RandomPassword)
-node.normal_unless['bareos']['fd_password'] = random_password(length: 30, mode: :base64)
-node.normal_unless['bareos']['mon_password'] = random_password(length: 30, mode: :base64)
+node.default_unless['bareos']['fd_password'] = random_password(length: 30, mode: :base64)
+node.default_unless['bareos']['mon_password'] = random_password(length: 30, mode: :base64)
 node.save unless Chef::Config[:solo]
 
 # Installation of the BAREOS File Daemon

--- a/recipes/client.rb
+++ b/recipes/client.rb
@@ -19,8 +19,8 @@
 
 # Include the OpenSSL library for generating random passwords
 ::Chef::Recipe.send(:include, OpenSSLCookbook::RandomPassword)
-node.set_unless['bareos']['fd_password'] = random_password(length: 30, mode: :base64)
-node.set_unless['bareos']['mon_password'] = random_password(length: 30, mode: :base64)
+node.normal_unless['bareos']['fd_password'] = random_password(length: 30, mode: :base64)
+node.normal_unless['bareos']['mon_password'] = random_password(length: 30, mode: :base64)
 node.save unless Chef::Config[:solo]
 
 # Installation of the BAREOS File Daemon

--- a/recipes/graphite_plugin.rb
+++ b/recipes/graphite_plugin.rb
@@ -48,5 +48,5 @@ cron 'bareos_graphite_poller' do
     -c #{node['bareos']['plugins']['graphite']['config_path']}/graphite-poller.conf
   EOH
   mailto node['bareos']['plugins']['graphite']['mail_to']
-  only_if node['bareos']['plugins']['graphite']['cron_job']
+  only_if { node['bareos']['plugins']['graphite']['cron_job'] }
 end

--- a/recipes/graphite_plugin.rb
+++ b/recipes/graphite_plugin.rb
@@ -48,6 +48,5 @@ cron 'bareos_graphite_poller' do
     -c #{node['bareos']['plugins']['graphite']['config_path']}/graphite-poller.conf
   EOH
   mailto node['bareos']['plugins']['graphite']['mail_to']
-  user 'bareos'
-  minute '5'
+  only_if node['bareos']['plugins']['graphite']['cron_job']
 end

--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -22,8 +22,8 @@
 include_recipe 'chef-bareos::client'
 
 # Preparing Random Password for the director and mon, including OpenSSL library from client.rb
-node.normal_unless['bareos']['dir_password'] = random_password(length: 30, mode: :base64)
-node.normal_unless['bareos']['mon_password'] = random_password(length: 30, mode: :base64)
+node.default_unless['bareos']['dir_password'] = random_password(length: 30, mode: :base64)
+node.default_unless['bareos']['mon_password'] = random_password(length: 30, mode: :base64)
 node.save unless Chef::Config[:solo]
 
 # Install BAREOS Server Packages

--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -22,12 +22,12 @@
 include_recipe 'chef-bareos::client'
 
 # Preparing Random Password for the director and mon, including OpenSSL library from client.rb
-node.set_unless['bareos']['dir_password'] = random_password(length: 30, mode: :base64)
-node.set_unless['bareos']['mon_password'] = random_password(length: 30, mode: :base64)
+node.normal_unless['bareos']['dir_password'] = random_password(length: 30, mode: :base64)
+node.normal_unless['bareos']['mon_password'] = random_password(length: 30, mode: :base64)
 node.save unless Chef::Config[:solo]
 
 # Install BAREOS Server Packages
-%w( bareos-director bareos-tools ).each do |server_pkgs|
+%w(bareos-director bareos-tools).each do |server_pkgs|
   package server_pkgs do
     action :install
   end

--- a/recipes/storage.rb
+++ b/recipes/storage.rb
@@ -20,7 +20,7 @@
 # Include the OpenSSL cookbook library
 # Setup Storage Daemon Random Passwords
 ::Chef::Recipe.send(:include, OpenSSLCookbook::RandomPassword)
-node.normal_unless['bareos']['sd_password'] = random_password(length: 30, mode: :base64)
+node.default_unless['bareos']['sd_password'] = random_password(length: 30, mode: :base64)
 node.save unless Chef::Config[:solo]
 
 # Install BAREOS Storage Daemon Packages

--- a/recipes/storage.rb
+++ b/recipes/storage.rb
@@ -20,7 +20,7 @@
 # Include the OpenSSL cookbook library
 # Setup Storage Daemon Random Passwords
 ::Chef::Recipe.send(:include, OpenSSLCookbook::RandomPassword)
-node.set_unless['bareos']['sd_password'] = random_password(length: 30, mode: :base64)
+node.normal_unless['bareos']['sd_password'] = random_password(length: 30, mode: :base64)
 node.save unless Chef::Config[:solo]
 
 # Install BAREOS Storage Daemon Packages
@@ -63,7 +63,7 @@ end
 # SD Config
 template '/etc/bareos/bareos-sd.conf' do
   source 'bareos-sd.conf.erb'
-  mode 0640
+  mode '0640'
   owner 'bareos'
   group 'bareos'
   variables(

--- a/recipes/workstation.rb
+++ b/recipes/workstation.rb
@@ -34,7 +34,7 @@ bareos_dir = if Chef::Config[:solo]
 # bconsole config
 template '/etc/bareos/bconsole.conf' do
   source 'bconsole.conf.erb'
-  mode 0640
+  mode '0640'
   owner 'bareos'
   group 'bareos'
   variables(

--- a/spec/unit/recipes/graphite_plugin_spec.rb
+++ b/spec/unit/recipes/graphite_plugin_spec.rb
@@ -77,8 +77,8 @@ describe 'chef-bareos::graphite_plugin' do
         end
         it 'creates the bareos_graphite_poller cronjob with attributes' do
           expect(chef_run).to create_cron('bareos_graphite_poller').with(
-            minute:               '5',
-            user:                 'bareos',
+            minute:               '*',
+            user:                 'root',
             mailto:               'bareos'
           )
           chef_run

--- a/spec/unit/recipes/graphite_plugin_spec.rb
+++ b/spec/unit/recipes/graphite_plugin_spec.rb
@@ -15,9 +15,9 @@ describe 'chef-bareos::graphite_plugin' do
       context "on an #{platform.capitalize}-#{version} box" do
         let(:chef_run) do
           runner = ChefSpec::ServerRunner.new(platform: platform, version: version)
-          runner.node.set['bareos']['plugins']['graphite']['config_path'] = '/etc/bareos'
-          runner.node.set['bareos']['plugins']['graphite']['plugin_path'] = '/usr/sbin'
-          runner.node.set['bareos']['plugins']['graphite']['mailto'] = 'bareos'
+          runner.node.default['bareos']['plugins']['graphite']['config_path'] = '/etc/bareos'
+          runner.node.default['bareos']['plugins']['graphite']['plugin_path'] = '/usr/sbin'
+          runner.node.default['bareos']['plugins']['graphite']['mailto'] = 'bareos'
           runner.converge(described_recipe)
         end
         it 'converges successfully' do

--- a/spec/unit/recipes/graphite_plugin_spec.rb
+++ b/spec/unit/recipes/graphite_plugin_spec.rb
@@ -18,6 +18,7 @@ describe 'chef-bareos::graphite_plugin' do
           runner.node.default['bareos']['plugins']['graphite']['config_path'] = '/etc/bareos'
           runner.node.default['bareos']['plugins']['graphite']['plugin_path'] = '/usr/sbin'
           runner.node.default['bareos']['plugins']['graphite']['mailto'] = 'bareos'
+          runner.node.default['bareos']['plugins']['graphite']['cron_job'] = true
           runner.converge(described_recipe)
         end
         it 'converges successfully' do

--- a/test/integration/bareos-aio-server/serverspec/bareos_spec.rb
+++ b/test/integration/bareos-aio-server/serverspec/bareos_spec.rb
@@ -37,5 +37,5 @@ describe file('/usr/sbin/bareos-graphite-poller.py') do
 end
 
 describe cron do
-  it { should have_entry('5 * * * *     /usr/sbin/bareos-graphite-poller.py    -c /etc/bareos/graphite-poller.conf').with_user('bareos') }
+  it { should have_entry('* * * * *     /usr/sbin/bareos-graphite-poller.py    -c /etc/bareos/graphite-poller.conf').with_user('root') }
 end


### PR DESCRIPTION
After using this recipe in the last iteration for a while, I found some trouble with how the cronjob was being configured. This should get the job running as root again but maintain that only the designated attribute defined bareos mailto user is being mailed for the cronjob. Also, by adding a guard for the cron resource, the cronjob wont just get enabled by default but is easily activated in a wrapper cookbook if desired. This should be ready to get pushed to supermarket when you have time @sitle. Thanks.
